### PR TITLE
Improved npm bundle dependencies within Makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 build
 thirdparty/checkouts
 tmp
+node_modules

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,17 @@ mesg_step = echo "$(1)"
 mesg_ok = echo "result: $(shell tput setaf 2)ok$(shell tput sgr0)"
 mesg_fail = (echo "result: $(shell tput setaf 1)fail$(shell tput sgr0)" && false)
 
+pathsearch = $(firstword $(wildcard $(addsuffix /$(1),$(subst :, ,$(PATH)))))
+
+npm_install = \
+	$(call mesg_start,main,Installing $(1) via npm ...); \
+	$(NPM) install $(1) >/dev/null 2>&1 && \
+		$(call mesg_ok) || $(call mesg_fail)
+
+# Npm
+NPM ?= npm
+PATH := $(PATH):$(shell $(NPM) bin)
+
 # Go
 GOPATH = $(realpath $(TEMP_DIR))
 export GOPATH
@@ -26,19 +37,40 @@ PANDOC_ARGS = --standalone --to man
 
 UGLIFYJS ?= uglifyjs
 UGLIFYSCRIPT_ARGS = --comments --compress --mangle --screw-ie8
+NPM_UGLIFYJS = uglify-js
 
 JSHINT ?= jshint
 JSHINT_ARGS = --show-non-errors
+NPM_JSHINT = jshint
 
 LESSC ?= lessc
 LESSC_ARGS = --no-color
+NPM_LESSC = less
+
 
 all: build lint
 
 clean:
 	@$(call mesg_start,main,Cleaning temporary files...)
-	@rm -rf $(TEMP_DIR) && \
+	@rm -rf node_modules $(TEMP_DIR) && \
 		$(call mesg_ok) || $(call mesg_fail)
+
+
+# JS
+lessc:
+	@if [ -z "$(call pathsearch,$(LESSC))" ]; then \
+		$(call npm_install,$(NPM_LESSC)); \
+	fi
+
+uglifyjs:
+	@if [ -z "$(call pathsearch,$(UGLIFYJS))" ]; then \
+		$(call npm_install,$(NPM_UGLIFYJS)); \
+	fi
+
+jshint:
+	@if [ -z "$(call pathsearch,$(JSHINT))" ]; then \
+		$(call npm_install,$(NPM_JSHINT)); \
+	fi
 
 .PHONY: build
 build: build-bin build-man build-static
@@ -183,7 +215,7 @@ HTML_SRC = $(wildcard cmd/facette/html/*/*.html) \
 
 HTML_OUTPUT = $(TEMP_DIR)/html
 
-$(SCRIPT_OUTPUT): $(SCRIPT_SRC)
+$(SCRIPT_OUTPUT): uglifyjs $(SCRIPT_SRC)
 	@$(call mesg_start,static,Merging script files into $(notdir $(SCRIPT_OUTPUT:.js=.src.js))...)
 	@install -d -m 0755 $(TEMP_DIR)/static && cat $(SCRIPT_SRC) >$(SCRIPT_OUTPUT:.js=.src.js) && \
 		$(call mesg_ok) || $(call mesg_fail)
@@ -202,7 +234,7 @@ $(MESG_OUTPUT): $(MESG_SRC)
 		sed -e 's/^\s\+//g;s/\s\+$$//g' $(MESG_SRC) | sed -e ':a;N;s/\n//;ta' >$(MESG_OUTPUT) && \
 		$(call mesg_ok) || $(call mesg_fail)
 
-$(STYLE_OUTPUT): $(STYLE_SRC)
+$(STYLE_OUTPUT): lessc $(STYLE_SRC)
 	@$(call mesg_start,static,Merging style files into $(notdir $(STYLE_OUTPUT:.css=.src.css))...)
 	@install -d -m 0755 $(TEMP_DIR)/static && cat $(STYLE_SRC) >$(STYLE_OUTPUT:.css=.src.css) && \
 		$(call mesg_ok) || $(call mesg_fail)
@@ -210,7 +242,7 @@ $(STYLE_OUTPUT): $(STYLE_SRC)
 	@$(LESSC) $(LESSC_ARGS) --yui-compress $(STYLE_OUTPUT:.css=.src.css) >$(STYLE_OUTPUT) && \
 		$(call mesg_ok) || $(call mesg_fail)
 
-$(STYLE_PRINT_OUTPUT): $(STYLE_PRINT_SRC)
+$(STYLE_PRINT_OUTPUT): lessc $(STYLE_PRINT_SRC)
 	@$(call mesg_start,static,Merging style files into $(notdir $(STYLE_PRINT_OUTPUT:.css=.src.css))...)
 	@install -d -m 0755 $(TEMP_DIR)/static && cat $(STYLE_PRINT_SRC) >$(STYLE_PRINT_OUTPUT:.css=.src.css) && \
 		$(call mesg_ok) || $(call mesg_fail)
@@ -250,7 +282,7 @@ devel-static: install-static
 		cp $$ENTRY $(PREFIX)/share/static/`basename $$ENTRY | sed -e 's@\.src\.js$$@.js@'`; \
 	done) && $(call mesg_ok) || $(call mesg_fail)
 
-lint-static: $(SCRIPT_OUTPUT)
+lint-static: jshint $(SCRIPT_OUTPUT)
 	@$(call mesg_start,lint,Checking $(notdir $(SCRIPT_OUTPUT:.js=.src.js)) with JSHint...)
 	-@$(JSHINT) $(JSHINT_ARGS) $(SCRIPT_OUTPUT:.js=.src.js) && \
 		$(call mesg_ok) || $(call mesg_fail)


### PR DESCRIPTION
As discussed, please see my improved npm bundle within make. 
It searches for related command into env PATH and install npm corresponding package if nothing was found. I have also removed ugly dep target and include each component into make target.

I choosed not to factorize every piece of code - makefile are hard enough to read and maintain :-)

Regards.
