### PR TITLE
Add Dockerfile to have an easy build env

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,32 @@
+FROM debian:jessie
+
+RUN apt-get update && apt-get install --no-install-recommends -y \
+    ca-certificates \
+    curl \
+    librrd-dev \
+    pandoc \
+    npm \
+    nodejs \
+    build-essential \
+    git-core && \
+    ln -s /usr/bin/nodejs /usr/bin/node
+
+RUN curl -s https://storage.googleapis.com/golang/go1.3.linux-amd64.tar.gz | tar -v -C /usr/local -xz
+ENV PATH $PATH:/usr/local/go/bin:/go/bin
+
+COPY . /facette
+WORKDIR /facette
+ 
+RUN make && make install && \
+    mkdir -p /etc/facette && \
+    cp docs/examples/facette.json /etc/facette/facette.json
+
+RUN mkdir -p /usr/share/facette && \
+    mkdir -p /var/lib/facette && \
+    mkdir -p /etc/facette/providers && \
+    mkdir -p /var/run/facette && \
+    chown -R 1:1 /usr/share/facette /var/lib/facette /etc/facette /var/run/facette
+
+USER 1
+EXPOSE 12003
+ENTRYPOINT ["facette"]

--- a/docs/examples/facette.json
+++ b/docs/examples/facette.json
@@ -1,6 +1,6 @@
 {
 	"bind": ":12003",
-	"base_dir": "/usr/share/facette",
+	"base_dir": "/usr/local/share/facette",
 	"providers_dir": "/etc/facette/providers",
 	"data_dir": "/var/lib/facette",
 	"pid_file": "/var/run/facette/facette.pid"


### PR DESCRIPTION
Facette has many dependencies and it was hard to get the correct node
version just to compile.  Adding a Dockerfile makes this much easier to
build and to run facette.

To buid:  docker build -t facette .

To run with a dynamic port: docker run -dP facette
To run with a static port of 80: docker run -d -p 80:12003 facette

I also had to update the example json file to use.
