### PR TITLE
Enable logging by default, enhances experience for beginners

### DIFF
--- a/debian/facette.default
+++ b/debian/facette.default
@@ -6,4 +6,4 @@
 ENABLED=false
 
 # Options for facette
-OPTIONS="-c /etc/facette/facette.json"
+OPTIONS="-c /etc/facette/facette.json -l /var/log/facette/facette.log"


### PR DESCRIPTION
There should probably be a logrotate script coming with logging enabled by default.

There's a propper config file for logrotate under [1]. Since I'm not into debian packing too much by now I'm just attaching it as a comment along with this pull request.

[1] /etc/logrotate.d/facette:
/var/log/facette/*.log {
        weekly
        missingok
        rotate 4
        compress
        delaycompress
        notifempty
        create 640 facette facette
        sharedscripts
        postrotate
                /etc/init.d/facette reload > /dev/null
        endscript
}
