### PR TITLE
Add more information to legend when a graph is generated from a group

### DIFF
--- a/pkg/plot/plot.go
+++ b/pkg/plot/plot.go
@@ -195,7 +195,7 @@ func (series *Series) Scale(factor Value) {
 
 // Summarize calculates the min/max/average/last and percentile values of a series of plots, and stores the results
 // into the Summary map.
-func (series Series) Summarize(percentiles []float64) {
+func (series *Series) Summarize(percentiles []float64) {
 	var (
 		min, max, total Value
 		nValidPlots     int64
@@ -232,7 +232,7 @@ func (series Series) Summarize(percentiles []float64) {
 }
 
 // Percentiles calculates the percentile values of a series of plots.
-func (series Series) Percentiles(percentiles []float64) {
+func (series *Series) Percentiles(percentiles []float64) {
 	var set []float64
 
 	for i := range series.Plots {

--- a/pkg/server/api_library_graph.go
+++ b/pkg/server/api_library_graph.go
@@ -291,10 +291,10 @@ func (server *Server) serveGraphPlots(writer http.ResponseWriter, request *http.
 		}
 
 		if len(plotSeries) > 1 {
-			for index, entry := range plotSeries {
-				entry.Name = fmt.Sprintf("%s (%s)", groupItem.Name, query.Series[index].Metric.Name)
-				entry.Summarize(plotReq.Percentiles)
-				entry.Downsample(plotReq.Sample, plot.ConsolidateAverage)
+			for index := range plotSeries {
+				plotSeries[index].Name = fmt.Sprintf("%s (%s)", query.Series[index].Metric.Source, query.Series[index].Metric.Name)
+				plotSeries[index].Summarize(plotReq.Percentiles)
+				plotSeries[index].Downsample(plotReq.Sample, plot.ConsolidateAverage)
 			}
 		} else if len(plotSeries) == 1 {
 			plotSeries[0].Name = groupItem.Name


### PR DESCRIPTION
Thanks for the great tool, I found that I would like a little more detail in some graphs that are generated from groups.

For me anything generated from a group was just displaying "series0' etc.... In the code there was a 'pretty' name but it wasn't being displayed. I added a little more specificity so we can identify not just the group but the server as well. But this issue may be better solved with slices/pointers in a few additional places, but i tried to keep my changes to a minimum.

All the tests seems to pass for me, should I be including additional tests?
