### PR TITLE
Added `cursor: pointer` on iOS-like checkbox switches

### DIFF
--- a/cmd/facette/style/form.less
+++ b/cmd/facette/style/form.less
@@ -75,6 +75,7 @@ input[type=checkbox] + label::before {
 	text-align: center;
 	vertical-align: middle;
 	width: 1.25em;
+	cursor: pointer;
 }
 
 input[type=checkbox]:checked + label::before {


### PR DESCRIPTION
I believe it is important for user experience to always have a "pointer" cursor for clickable UI elements.
