### PR TITLE
Added compatibility for RRDtool 1.3.x

### DIFF
--- a/pkg/connector/rrd.go
+++ b/pkg/connector/rrd.go
@@ -199,12 +199,16 @@ func (connector *RRDConnector) Refresh(originName string, outputChan chan<- *cat
 			connector.metrics[sourceName] = make(map[string]*rrdMetric)
 		}
 
+		logger.Log(logger.LevelDebug, "Refresh", "rrd[%s]: Processing file %s", connector.name, filePath)
+
 		// Extract metric information from .rrd file
 		info, err := rrd.Info(filePath)
 		if err != nil {
 			logger.Log(logger.LevelWarning, "connector", "rrd[%s]: %s", connector.name, err)
 			return nil
 		}
+
+		logger.Log(logger.LevelDebug, "Refresh", "rrd[%s]: Info: %s", connector.name, info)
 
 		// Extract consolidation functions list
 		cfSet := set.New(set.ThreadSafe)
@@ -219,8 +223,10 @@ func (connector *RRDConnector) Refresh(originName string, outputChan chan<- *cat
 
 		cfList := set.StringSlice(cfSet)
 
-		if _, ok := info["ds.index"]; ok {
-			indexes, ok := info["ds.index"].(map[string]interface{})
+		logger.Log(logger.LevelDebug, "Refresh", "rrd[%s]: DS: %s", connector.name, info["ds"])
+
+		if _, ok := info["ds.value"]; ok {
+			indexes, ok := info["ds.value"].(map[string]interface{})
 			if !ok {
 				return nil
 			}
@@ -228,6 +234,8 @@ func (connector *RRDConnector) Refresh(originName string, outputChan chan<- *cat
 			for dsName := range indexes {
 				for _, cfName := range cfList {
 					metricFullName := metricName + "/" + dsName + "/" + strings.ToLower(cfName)
+
+					logger.Log(logger.LevelDebug, "Refresh", "rrd[%s]: Found: %s", connector.name, metricFullName)
 
 					connector.metrics[sourceName][metricFullName] = &rrdMetric{
 						Dataset:  dsName,

--- a/thirdparty/github.com/ziutek/rrd/rrdfunc.c
+++ b/thirdparty/github.com/ziutek/rrd/rrdfunc.c
@@ -1,5 +1,10 @@
 #include <stdlib.h>
+#include <string.h>
 #include <rrd.h>
+
+#ifndef __COMPAT_RRDTOOL_13x
+#	define __COMPAT_RRDTOOL_13x
+#endif
 
 char *rrdError() {
 	char *err = NULL;
@@ -36,7 +41,13 @@ char *rrdGraph(rrd_info_t **ret, int argc, char **argv) {
 
 char *rrdInfo(rrd_info_t **ret, char *filename) {
 	rrd_clear_error();
+#ifdef __COMPAT_RRDTOOL_13x
+	//RRDtool 1.3.x does not export rrd_info_r
+	char *argv[2] = {NULL,filename};
+	*ret = rrd_info(2,argv);
+#else
 	*ret = rrd_info_r(filename);
+#endif
 	return rrdError();
 }
 


### PR DESCRIPTION
- I'm using RHEL 6 as OS. This comes with RRDtool 1.3.8. I added compatibility code for the RRDtool 1.3.x line. I have _not_ tested my changes against RRDtool 1.4, so please be careful when integrating.
- Test environment: RHEL 6 (Kernel 2.6.32-504.3.3.el6.x86_64), RRDtool 1.3.8 (package), collectd 4.10.9 (package), facette (current git master)
- Added missing header at rrdfunc.c