### PR TITLE
Support for multiple graph yAxes

### DIFF
--- a/cmd/facette/js/graph.js
+++ b/cmd/facette/js/graph.js
@@ -146,6 +146,8 @@ function graphDraw(graph, postpone, delay, preview) {
                     startTime,
                     endTime,
                     seriesData = {},
+                    seenUnits = {},
+                    unit,
                     i,
                     j;
 
@@ -397,9 +399,7 @@ function graphDraw(graph, postpone, delay, preview) {
                     break;
                 }
 
-                var seenUnits = {};
                 for (i in data.series) {
-                    var unit;
                     // Transform unix epochs to Date objects
                     for (j in data.series[i].plots)
                         data.series[i].plots[j] = [data.series[i].plots[j][0] * 1000, data.series[i].plots[j][1]];

--- a/cmd/facette/js/graph.js
+++ b/cmd/facette/js/graph.js
@@ -365,7 +365,7 @@ function graphDraw(graph, postpone, delay, preview) {
                     };
 
                     if (data.unit_legend)
-                        highchartOpts.yAxis.title.text = data.unit_legend;
+                        highchartOpts.yAxis[0].title.text = data.unit_legend;
 
                     if (graphOpts.zoom) {
                         highchartOpts.chart.events.selection = function (e) {

--- a/cmd/facette/js/graph.js
+++ b/cmd/facette/js/graph.js
@@ -260,6 +260,7 @@ function graphDraw(graph, postpone, delay, preview) {
                                 stacks = {},
                                 i,
                                 stackName,
+                                unitTotal = {},
                                 total;
 
                             for (i in this.points) {
@@ -270,6 +271,7 @@ function graphDraw(graph, postpone, delay, preview) {
                                     name: this.points[i].series.name,
                                     value: this.points[i].y,
                                     color: this.points[i].series.color,
+                                    unit: this.points[i].series.yAxis.axisTitle ? this.points[i].series.yAxis.axisTitle.textStr : undefined,
                                 });
                             }
 
@@ -282,14 +284,29 @@ function graphDraw(graph, postpone, delay, preview) {
                                     tooltip += '<div><span class="highcharts-tooltip-color" style="background-color: ' +
                                         stacks[stackName][i].color + '"></span> ' + stacks[stackName][i].name +
                                         ': <strong>' + (stacks[stackName][i].value !== null ?
-                                        formatValue(stacks[stackName][i].value, data.unit_type) : 'null') +
+                                        formatValue(stacks[stackName][i].value, data.unit_type, stacks[stackName][i].unit) : 'null') +
                                         '</strong></div>';
 
-                                    if (stacks[stackName][i].value !== null)
+                                    if (stacks[stackName][i].value !== null) {
                                         total += stacks[stackName][i].value;
+                                        if (stacks[stackName][i].unit) {
+                                            if (!unitTotal[stacks[stackName][i].unit])
+                                                unitTotal[stacks[stackName][i].unit] = { 'value' : 0, 'count' : 0 };
+                                            unitTotal[stacks[stackName][i].unit].value += stacks[stackName][i].value;
+                                            unitTotal[stacks[stackName][i].unit].count += 1;
+                                        }
+                                    }
                                 }
 
                                 if (stacks[stackName].length > 1) {
+                                    tooltip += '<hr>';
+                                    for (unit in unitTotal) {
+                                        // only print totals for units used in multiple series
+                                        if (unitTotal[unit].count > 1) 
+                                            tooltip += '<div class="highcharts-tooltip-total">Total (' + unit + '): <strong>' +
+                                            (total !== null ? formatValue(unitTotal[unit].value, data.unit_type, unit) : 'null') +
+                                            '</strong></div>';
+                                    }
                                     tooltip += '<div class="highcharts-tooltip-total">Total: <strong>' +
                                         (total !== null ? formatValue(total, data.unit_type) : 'null') +
                                         '</strong></div>';

--- a/cmd/facette/js/graph.js
+++ b/cmd/facette/js/graph.js
@@ -304,7 +304,7 @@ function graphDraw(graph, postpone, delay, preview) {
                         min: startTime.valueOf(),
                         type: 'datetime'
                     },
-                    yAxis: {
+                    yAxis: [{
                         labels: {
                             formatter: function () {
                                 return formatValue(this.value, data.unit_type);
@@ -314,7 +314,7 @@ function graphDraw(graph, postpone, delay, preview) {
                         title: {
                             text: null
                         }
-                    },
+                    }],
                     _data: {
                         plotlines: {}
                     },
@@ -397,23 +397,36 @@ function graphDraw(graph, postpone, delay, preview) {
                     break;
                 }
 
+                var seenUnits = {};
                 for (i in data.series) {
+                    var unit;
                     // Transform unix epochs to Date objects
                     for (j in data.series[i].plots)
                         data.series[i].plots[j] = [data.series[i].plots[j][0] * 1000, data.series[i].plots[j][1]];
 
+                    if (data.series[i].options && data.series[i].options.unit && data.series[i].options.unit != "") {
+                        unit = data.series[i].options.unit;
+                        seenUnits[unit] = 1; 
+                    } else {
+                        unit = 0;
+                    }
                     highchartOpts.series.push({
                         id: data.series[i].name,
                         name: data.series[i].name,
                         stack: 'stack' + data.series[i].stack_id,
                         data: data.series[i].plots,
-                        color: data.series[i].options ? data.series[i].options.color : null
+                        color: data.series[i].options ? data.series[i].options.color : null,
+                        yAxis: unit
                     });
 
                     seriesData[data.series[i].name] = {
                         summary: data.series[i].summary,
                         options: data.series[i].options
                     };
+                }
+ 
+                for (unit in seenUnits) {
+                    highchartOpts.yAxis.push({ id: unit, title: { text: unit }, opposite : true });
                 }
 
                 // Prepare legend spacing

--- a/pkg/library/graph.go
+++ b/pkg/library/graph.go
@@ -91,6 +91,7 @@ func (group *OperGroup) String() string {
 		"OperGroup{Name:%q Type:%d StackID:%d Series:[%s] Options:%v}",
 		group.Name,
 		group.Type,
+		group.StackID,
 		func(series []*Series) string {
 			seriesStrings := make([]string, len(series))
 			for i, entry := range series {

--- a/pkg/server/api_plot.go
+++ b/pkg/server/api_plot.go
@@ -357,7 +357,9 @@ func makePlotsResponse(plotSeries map[string][]plot.Series, plotReq *PlotRequest
 					plotItem.Scale(plot.Value(scale))
 				}
 
-				seriesOptions[seriesItem.Name] = seriesItem.Options
+				if len(seriesItem.Options) != 0 {
+					seriesOptions[seriesItem.Name] = seriesItem.Options
+				}
 
 				groupSeries = append(groupSeries, plotItem)
 			}


### PR DESCRIPTION
Hi All,
having different units (like mem-free in bytes and loadavg) in one graph with one yAxis won't show up a curve for loadavg due to scaling issues. So, adding further yAxes based on the series units, seems like a good thing to do.

To get this done, I stumbled over problems with plot, which did provided Options for groups of series.
Another thing I found was the missing StackID field in OperGroup.

This PR is meant to be a basis for discussion, and I suspect that the plot issue needs some proper solution.
However, I find the multi-yAxes feature quite useful, and the PR works for me, for now. 

Hope you like it..
Matthias
