### PR TITLE
Fix for #182: Last is always null

### DIFF
--- a/pkg/plot/plot.go
+++ b/pkg/plot/plot.go
@@ -116,8 +116,8 @@ func (series *Series) Scale(factor Value) {
 func (series *Series) Summarize(percentiles []float64) {
 	var (
 		min, max, total, current Value
-		nValidPlots     int64
-		nPlots          = len(series.Plots)
+		nValidPlots              int64
+		nPlots                   = len(series.Plots)
 	)
 
 	if nPlots > 0 {

--- a/pkg/plot/plot.go
+++ b/pkg/plot/plot.go
@@ -117,12 +117,10 @@ func (series *Series) Summarize(percentiles []float64) {
 	var (
 		min, max, total, current Value
 		nValidPlots              int64
-		nPlots                   = len(series.Plots)
 	)
 
-	if nPlots > 0 {
-		min = series.Plots[0].Value
-	}
+	min = Value(math.NaN())
+	max = Value(math.NaN())
 
 	for i := range series.Plots {
 		if !series.Plots[i].Value.IsNaN() {
@@ -130,8 +128,7 @@ func (series *Series) Summarize(percentiles []float64) {
 			if current < min || min.IsNaN() {
 				min = series.Plots[i].Value
 			}
-
-			if current > max {
+			if current > max || max.IsNaN() {
 				max = current
 			}
 

--- a/pkg/plot/plot.go
+++ b/pkg/plot/plot.go
@@ -115,27 +115,27 @@ func (series *Series) Scale(factor Value) {
 // into the Summary map.
 func (series *Series) Summarize(percentiles []float64) {
 	var (
-		min, max, total Value
+		min, max, total, current Value
 		nValidPlots     int64
 		nPlots          = len(series.Plots)
 	)
 
 	if nPlots > 0 {
 		min = series.Plots[0].Value
-		series.Summary["last"] = series.Plots[nPlots-1].Value
 	}
 
 	for i := range series.Plots {
-		if !series.Plots[i].Value.IsNaN() && series.Plots[i].Value < min || min.IsNaN() {
-			min = series.Plots[i].Value
-		}
-
-		if series.Plots[i].Value > max {
-			max = series.Plots[i].Value
-		}
-
 		if !series.Plots[i].Value.IsNaN() {
-			total += series.Plots[i].Value
+			current = series.Plots[i].Value
+			if current < min || min.IsNaN() {
+				min = series.Plots[i].Value
+			}
+
+			if current > max {
+				max = current
+			}
+
+			total += current
 			nValidPlots++
 		}
 	}
@@ -147,6 +147,7 @@ func (series *Series) Summarize(percentiles []float64) {
 	series.Summary["min"] = min
 	series.Summary["max"] = max
 	series.Summary["avg"] = total / Value(nValidPlots)
+	series.Summary["last"] = current
 
 	if len(percentiles) > 0 {
 		series.Percentiles(percentiles)

--- a/pkg/plot/plot_test.go
+++ b/pkg/plot/plot_test.go
@@ -13,8 +13,8 @@ type sampleTest struct {
 }
 
 var (
-	plotSeries         Series
-	startTime, endTime time.Time
+	plotSeries, plotSeriesNeg Series
+	startTime, endTime        time.Time
 )
 
 func init() {
@@ -29,11 +29,23 @@ func init() {
 		Summary: make(map[string]Value),
 	}
 
+	plotSeriesNeg = Series{
+		Plots: []Plot{
+			{Value: Value(math.NaN())}, {Value: -61}, {Value: -69}, {Value: -98}, {Value: -56}, {Value: -43},
+			{Value: -68}, {Value: Value(math.NaN())}, {Value: -87}, {Value: -95}, {Value: -69}, {Value: -79},
+			{Value: -99}, {Value: -54}, {Value: -88}, {Value: Value(math.NaN())}, {Value: -99}, {Value: -77},
+			{Value: -85}, {Value: Value(math.NaN())}, {Value: -62}, {Value: -71}, {Value: -78}, {Value: -72},
+			{Value: -89}, {Value: -70}, {Value: -96}, {Value: -93}, {Value: -66}, {Value: Value(math.NaN())},
+		},
+		Summary: make(map[string]Value),
+	}
+
 	startTime = time.Now()
 	endTime = startTime.Add(time.Duration(len(plotSeries.Plots)) * time.Second)
 
 	for plotIndex := range plotSeries.Plots {
 		plotSeries.Plots[plotIndex].Time = startTime.Add(time.Duration(plotIndex) * time.Second)
+		plotSeriesNeg.Plots[plotIndex].Time = startTime.Add(time.Duration(plotIndex) * time.Second)
 	}
 }
 
@@ -58,19 +70,29 @@ func Test_SeriesScale(test *testing.T) {
 
 func Test_SeriesSummarize(test *testing.T) {
 	var (
-		minExpectedValue, maxExpectedValue, avgExpectedValue, lastExpectedValue Value
-		pct20thExpectedValue, pct50thExpectedValue, pct90thExpectedValue        Value
+		minExpectedValue, maxExpectedValue, avgExpectedValue, lastExpectedValue             Value
+		pct20thExpectedValue, pct50thExpectedValue, pct90thExpectedValue                    Value
+		minExpectedNegValue, maxExpectedNegValue, avgExpectedNegValue, lastExpectedNegValue Value
+		pct20thExpectedNegValue, pct50thExpectedNegValue, pct90thExpectedNegValue           Value
 	)
 
 	minExpectedValue = 43
+	minExpectedNegValue = -99
 	maxExpectedValue = 99
+	maxExpectedNegValue = -43
 	avgExpectedValue = 76.96
+	avgExpectedNegValue = -76.96
 	lastExpectedValue = 66
+	lastExpectedNegValue = -66
 	pct20thExpectedValue = 62.8
+	pct20thExpectedNegValue = -94.6
 	pct50thExpectedValue = 77
+	pct50thExpectedNegValue = -77
 	pct90thExpectedValue = 98.4
+	pct90thExpectedNegValue = -55.199999999999996
 
 	plotSeries.Summarize([]float64{20, 50, 90})
+	plotSeriesNeg.Summarize([]float64{20, 50, 90})
 
 	if plotSeries.Summary["min"] != minExpectedValue {
 		test.Logf("\nExpected min=%g\nbut got %g", minExpectedValue, plotSeries.Summary["min"])
@@ -113,6 +135,51 @@ func Test_SeriesSummarize(test *testing.T) {
 		test.Fail()
 		return
 	}
+
+	// Summaries for negative only plotSeries
+
+	if plotSeriesNeg.Summary["min"] != minExpectedNegValue {
+		test.Logf("\nExpected min=%g\nbut got %g", minExpectedNegValue, plotSeriesNeg.Summary["min"])
+		test.Fail()
+		return
+	}
+
+	if plotSeriesNeg.Summary["max"] != maxExpectedNegValue {
+		test.Logf("\nExpected max=%g\nbut got %g", maxExpectedNegValue, plotSeriesNeg.Summary["max"])
+		test.Fail()
+		return
+	}
+
+	if plotSeriesNeg.Summary["avg"] != avgExpectedNegValue {
+		test.Logf("\nExpected avg=%g\nbut got %g", avgExpectedNegValue, plotSeriesNeg.Summary["avg"])
+		test.Fail()
+		return
+	}
+
+	if plotSeriesNeg.Summary["last"] != lastExpectedNegValue {
+		test.Logf("\nExpected last=%g\nbut got %g", lastExpectedNegValue, plotSeriesNeg.Summary["last"])
+		test.Fail()
+		return
+	}
+
+	if plotSeriesNeg.Summary["20th"] != pct20thExpectedNegValue {
+		test.Logf("\nExpected 20th=%g\nbut got %g", pct20thExpectedNegValue, plotSeriesNeg.Summary["20th"])
+		test.Fail()
+		return
+	}
+
+	if plotSeriesNeg.Summary["50th"] != pct50thExpectedNegValue {
+		test.Logf("\nExpected 50th=%g\nbut got %g", pct50thExpectedNegValue, plotSeriesNeg.Summary["50th"])
+		test.Fail()
+		return
+	}
+
+	if plotSeriesNeg.Summary["90th"] != pct90thExpectedNegValue {
+		test.Logf("\nExpected 90th=%g\nbut got %g", pct90thExpectedNegValue, plotSeriesNeg.Summary["90th"])
+		test.Fail()
+		return
+	}
+
 }
 
 func compareSeries(expected, actual Series) error {

--- a/pkg/plot/plot_test.go
+++ b/pkg/plot/plot_test.go
@@ -65,7 +65,7 @@ func Test_SeriesSummarize(test *testing.T) {
 	minExpectedValue = 43
 	maxExpectedValue = 99
 	avgExpectedValue = 76.96
-	lastExpectedValue = Value(math.NaN())
+	lastExpectedValue = 66
 	pct20thExpectedValue = 62.8
 	pct50thExpectedValue = 77
 	pct90thExpectedValue = 98.4
@@ -90,7 +90,7 @@ func Test_SeriesSummarize(test *testing.T) {
 		return
 	}
 
-	if !plotSeries.Summary["last"].IsNaN() {
+	if plotSeries.Summary["last"] != lastExpectedValue {
 		test.Logf("\nExpected last=%g\nbut got %g", lastExpectedValue, plotSeries.Summary["last"])
 		test.Fail()
 		return


### PR DESCRIPTION
While fiddling around with multiple yAxes, I've also stumbled over the fact that the "last" value is always null. There is already an existing Issue (#182). So here's a fix.

Vincent, if you already have a better solution for this, feel free to dump this PR.

 So here's the commit message..
```
Especially with asynchronous writing to RRD files, plot won't be able to
get the latest data. Instead the graph will end some seconds before. Now,
the "last" value is actually the last value shown in the graph.
```

The plot source a comment already mentions https://github.com/ziutek/rrd/pull/13. I didn't include it in the commit message, as even if this will be fixed some day, the problem with async backend writes will always be there.
