### PR TITLE
Missing requirements: node binary

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -12,7 +12,7 @@ Requirements
 
 Debian/Ubuntu:
 
-   apt-get install build-essential golang-go librrd-dev pkg-config npm pandoc
+   apt-get install build-essential golang-go librrd-dev pkg-config npm nodejs-legacy pandoc
 
 Mac OS X (with brew):
 


### PR DESCRIPTION
nodejs-legacy contains a symlink to /usr/bin/nodejs for compatibility (used by uglify-js and maybe other by calling "/usr/bin/env node" in shebang).