### PR TITLE
Update INSTALL to link configuration documentation

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -32,6 +32,11 @@ installation directory set the `PREFIX` variable:
 
    sudo make PREFIX=/path/to/directory install
 
+Configuration
+-------------
+
+Once installed, follow the configuration steps described here: http://docs.facette.io/configuration/
+
 Additional Targets
 ------------------
 


### PR DESCRIPTION
When a user comes from https://github.com/facette/facette, it reads the README and is then redirected to this file for Installation steps.

But once installed, there are no more resources linked here to configure it, hence this pull request