### PR TITLE
allow to apply UUIDs during library creation tasks

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -42,6 +42,7 @@ type Config struct {
 	ProvidersDir     string                     `json:"providers_dir"`
 	PidFile          string                     `json:"pid_file"`
 	URLPrefix        string                     `json:"url_prefix"`
+	ForeignUUID      bool                       `json:"foreign_uuid"`
 	ReadOnly         bool                       `json:"read_only"`
 	HideBuildDetails bool                       `json:"hide_build_details"`
 	Providers        map[string]*ProviderConfig `json:"-"`

--- a/pkg/library/item.go
+++ b/pkg/library/item.go
@@ -268,7 +268,7 @@ func (library *Library) LoadItem(id string, itemType int) error {
 }
 
 // StoreItem stores an item into the library.
-func (library *Library) StoreItem(item interface{}, itemType int) error {
+func (library *Library) StoreItem(item interface{}, itemType int, foreignIdAllowd bool) error {
 	var itemStruct *Item
 
 	switch itemType {
@@ -299,9 +299,13 @@ func (library *Library) StoreItem(item interface{}, itemType int) error {
 		}
 
 		itemStruct.ID = uuidTemp.String()
-	} else if !library.ItemExists(itemStruct.ID, itemType) {
-		return os.ErrNotExist
 	}
+        if library.ItemExists(itemStruct.ID, itemType) {
+                return os.ErrExist
+        } else if !foreignIdAllowd {
+                return os.ErrNotExist
+        }
+
 
 	// Check for name field presence/duplicates
 	if itemStruct.Name == "" {

--- a/pkg/server/api_library_collection.go
+++ b/pkg/server/api_library_collection.go
@@ -143,7 +143,7 @@ func (server *Server) serveCollection(writer http.ResponseWriter, request *http.
 		}
 
 		// Store collection data
-		err := server.Library.StoreItem(collectionTemp.Collection, library.LibraryItemCollection)
+		err := server.Library.StoreItem(collectionTemp.Collection, library.LibraryItemCollection, server.Config.ForeignUUID)
 		if response, status := server.parseError(writer, request, err); status != http.StatusOK {
 			logger.Log(logger.LevelError, "server", "%s", err)
 			server.serveResponse(writer, response, status)

--- a/pkg/server/api_library_collection.go
+++ b/pkg/server/api_library_collection.go
@@ -110,6 +110,7 @@ func (server *Server) serveCollection(writer http.ResponseWriter, request *http.
 			server.serveResponse(writer, serverResponse{mesgResourceInvalid}, http.StatusBadRequest)
 			return
 		}
+		// perhaps unmarshalling overwrites ID provided by URL, IMHO this is an API PUT bug
 
 		// Update parent relation
 		if item, _ := server.Library.GetItem(collectionTemp.Parent, library.LibraryItemCollection); item != nil {
@@ -143,7 +144,7 @@ func (server *Server) serveCollection(writer http.ResponseWriter, request *http.
 		}
 
 		// Store collection data
-		err := server.Library.StoreItem(collectionTemp.Collection, library.LibraryItemCollection, server.Config.ForeignUUID)
+		err := server.Library.StoreItem(collectionTemp.Collection, library.LibraryItemCollection, request.Method, server.Config.ForeignUUID)
 		if response, status := server.parseError(writer, request, err); status != http.StatusOK {
 			logger.Log(logger.LevelError, "server", "%s", err)
 			server.serveResponse(writer, response, status)

--- a/pkg/server/api_library_graph.go
+++ b/pkg/server/api_library_graph.go
@@ -109,7 +109,7 @@ func (server *Server) serveGraph(writer http.ResponseWriter, request *http.Reque
 		}
 
 		// Store graph item
-		err := server.Library.StoreItem(graph, library.LibraryItemGraph)
+		err := server.Library.StoreItem(graph, library.LibraryItemGraph, server.Config.ForeignUUID)
 		if response, status := server.parseError(writer, request, err); status != http.StatusOK {
 			logger.Log(logger.LevelError, "server", "%s", err)
 			server.serveResponse(writer, response, status)

--- a/pkg/server/api_library_graph.go
+++ b/pkg/server/api_library_graph.go
@@ -98,6 +98,10 @@ func (server *Server) serveGraph(writer http.ResponseWriter, request *http.Reque
 			server.serveResponse(writer, serverResponse{mesgResourceInvalid}, http.StatusBadRequest)
 			return
 		}
+		// perhaps unmarshalling overwrites ID provided by URL, IMHO this is an API PUT bug
+		// if request.Method == "PUT" {
+		//	graph.ID = graphID
+		// }
 
 		// Check for graph type consistency (either a graph or an instance but not both)
 		if !graph.Template && (graph.Link != "" || len(graph.Attributes) > 0) &&
@@ -109,7 +113,7 @@ func (server *Server) serveGraph(writer http.ResponseWriter, request *http.Reque
 		}
 
 		// Store graph item
-		err := server.Library.StoreItem(graph, library.LibraryItemGraph, server.Config.ForeignUUID)
+		err := server.Library.StoreItem(graph, library.LibraryItemGraph, request.Method, server.Config.ForeignUUID)
 		if response, status := server.parseError(writer, request, err); status != http.StatusOK {
 			logger.Log(logger.LevelError, "server", "%s", err)
 			server.serveResponse(writer, response, status)

--- a/pkg/server/api_library_group.go
+++ b/pkg/server/api_library_group.go
@@ -113,7 +113,7 @@ func (server *Server) serveGroup(writer http.ResponseWriter, request *http.Reque
 		}
 
 		// Store group data
-		err := server.Library.StoreItem(group, groupType)
+		err := server.Library.StoreItem(group, groupType, server.Config.ForeignUUID)
 		if response, status := server.parseError(writer, request, err); status != http.StatusOK {
 			logger.Log(logger.LevelError, "server", "%s", err)
 			server.serveResponse(writer, response, status)

--- a/pkg/server/api_library_group.go
+++ b/pkg/server/api_library_group.go
@@ -111,9 +111,13 @@ func (server *Server) serveGroup(writer http.ResponseWriter, request *http.Reque
 			server.serveResponse(writer, serverResponse{mesgResourceInvalid}, http.StatusBadRequest)
 			return
 		}
+		// perhaps unmarshalling overwrites ID provided by URL, IMHO this is an API PUT bug
+		// if request.Method == "PUT" {
+		//	group.ID = groupID
+		// }
 
 		// Store group data
-		err := server.Library.StoreItem(group, groupType, server.Config.ForeignUUID)
+		err := server.Library.StoreItem(group, groupType, request.Method, server.Config.ForeignUUID)
 		if response, status := server.parseError(writer, request, err); status != http.StatusOK {
 			logger.Log(logger.LevelError, "server", "%s", err)
 			server.serveResponse(writer, response, status)

--- a/pkg/server/api_library_scale.go
+++ b/pkg/server/api_library_scale.go
@@ -101,7 +101,7 @@ func (server *Server) serveScale(writer http.ResponseWriter, request *http.Reque
 		}
 
 		// Store scale data
-		err := server.Library.StoreItem(scale, library.LibraryItemScale)
+		err := server.Library.StoreItem(scale, library.LibraryItemScale, server.Config.ForeignUUID)
 		if response, status := server.parseError(writer, request, err); status != http.StatusOK {
 			logger.Log(logger.LevelError, "server", "%s", err)
 			server.serveResponse(writer, response, status)

--- a/pkg/server/api_library_scale.go
+++ b/pkg/server/api_library_scale.go
@@ -99,9 +99,13 @@ func (server *Server) serveScale(writer http.ResponseWriter, request *http.Reque
 			server.serveResponse(writer, serverResponse{mesgResourceInvalid}, http.StatusBadRequest)
 			return
 		}
+		// perhaps unmarshalling overwrites ID provided by URL, IMHO this is an API PUT bug
+		// if request.Method == "PUT" {
+		//	scale.ID = scaleID
+		// }
 
 		// Store scale data
-		err := server.Library.StoreItem(scale, library.LibraryItemScale, server.Config.ForeignUUID)
+		err := server.Library.StoreItem(scale, library.LibraryItemScale, request.Method, server.Config.ForeignUUID)
 		if response, status := server.parseError(writer, request, err); status != http.StatusOK {
 			logger.Log(logger.LevelError, "server", "%s", err)
 			server.serveResponse(writer, response, status)

--- a/pkg/server/api_library_unit.go
+++ b/pkg/server/api_library_unit.go
@@ -101,7 +101,7 @@ func (server *Server) serveUnit(writer http.ResponseWriter, request *http.Reques
 		}
 
 		// Store unit data
-		err := server.Library.StoreItem(unit, library.LibraryItemUnit)
+		err := server.Library.StoreItem(unit, library.LibraryItemUnit, server.Config.ForeignUUID)
 		if response, status := server.parseError(writer, request, err); status != http.StatusOK {
 			logger.Log(logger.LevelError, "server", "%s", err)
 			server.serveResponse(writer, response, status)

--- a/pkg/server/api_library_unit.go
+++ b/pkg/server/api_library_unit.go
@@ -99,9 +99,13 @@ func (server *Server) serveUnit(writer http.ResponseWriter, request *http.Reques
 			server.serveResponse(writer, serverResponse{mesgResourceInvalid}, http.StatusBadRequest)
 			return
 		}
+		// perhaps unmarshalling overwrites ID provided by URL, IMHO this is an API PUT bug
+		// if request.Method == "PUT" {
+		//	unit.ID = unitID
+		// }
 
 		// Store unit data
-		err := server.Library.StoreItem(unit, library.LibraryItemUnit, server.Config.ForeignUUID)
+		err := server.Library.StoreItem(unit, library.LibraryItemUnit, request.Method, server.Config.ForeignUUID)
 		if response, status := server.parseError(writer, request, err); status != http.StatusOK {
 			logger.Log(logger.LevelError, "server", "%s", err)
 			server.serveResponse(writer, response, status)


### PR DESCRIPTION
I added the possibility to provide your own UUID for library creation operations. The API was **not** changed by the patch. But it allows to provide UUIDs generated outside the scope of facette, now.

The API constrain to use facette generated UUIDs returned via `Location:` header only, makes implementation of 3rd-party graph generating and managing systems difficult. We are using nodejs scripts populating dynamic graphs and collections using name based RFC4122 UUIDs e.g.

I'm not sure if the constrain is a bug or a feature. Assuming it's a feature, users are able to disable it now via _facette.json_ `foreign_uuid: true`

Thanks for your patience.
I'm always excited to hear from you.
Best regards
