### PR TITLE
utils: Don't abort walkDir() when encountering a dangling symlink.

### DIFF
--- a/pkg/utils/os.go
+++ b/pkg/utils/os.go
@@ -3,6 +3,8 @@ package utils
 import (
 	"os"
 	"path/filepath"
+
+	"github.com/facette/facette/pkg/logger"
 )
 
 func walkDir(dirPath string, linkPath string, walkFunc filepath.WalkFunc) error {
@@ -17,7 +19,8 @@ func walkDir(dirPath string, linkPath string, walkFunc filepath.WalkFunc) error 
 		if mode == os.ModeSymlink {
 			realPath, err := filepath.EvalSymlinks(filePath)
 			if err != nil {
-				return err
+				logger.Log(logger.LevelWarning, "utils", "failed to resolve symlink %q: %v", filePath, err)
+				return nil
 			}
 
 			return walkDir(realPath, filePath, walkFunc)


### PR DESCRIPTION
I had a dangling symlink in the directory with RRD files. This caused Facette to discard the provider entirely, which is too harsh imho. This patch will change the behavior to emitting a warning and continuing in this case.