### PR TITLE
Issue #274 - fixing quote escaping in aliases to use url escapes

### DIFF
--- a/pkg/connector/graphite.go
+++ b/pkg/connector/graphite.go
@@ -230,7 +230,7 @@ func graphiteBuildQueryURL(query *plot.Query, graphiteSeries map[string]map[stri
 
 	for _, series := range query.Series {
 		queryURL += fmt.Sprintf(
-			"&target=alias(%s,\"%s\")",
+			"&target=alias(%s,%%22%s%%22)",
 			url.QueryEscape(graphiteSeries[series.Source][series.Metric]),
 			series.Name,
 		)


### PR DESCRIPTION
See Issue #274 
This replaces the \" escapes in the query URL with %%22, fixing direct (non-proxied) graphite requests.
See also #84 for the original issue
