### PR TITLE
Issue275

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+facette (0.3.1-1) unstable; urgency=medium
+
+  * Fix control file dependencies
+
+ -- Theral Mackey <tmackey@evernote.com>  Thu, 03 Dec 2015 16:50:23 -0800
+
 facette (0.3.0-1) unstable; urgency=medium
 
   * New upstream release

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-facette (0.3.1-1) unstable; urgency=medium
+facette (0.3.0-2) unstable; urgency=medium
 
   * Fix control file dependencies
 

--- a/debian/control
+++ b/debian/control
@@ -3,8 +3,9 @@ Section: utils
 Priority: optional
 Maintainer: Vincent Batoufflet <vincent@batoufflet.info>
 Build-Depends: debhelper (>= 8.0.0), quilt, dh-golang,
- golang-go (>= 1.1),
+ golang-go (>= 1.2),
  librrd-dev (>= 1.4),
+ nodejs-legacy,
  node-less,
  node-uglify,
  pandoc,


### PR DESCRIPTION
See #275 
Updates the version of golang-go package needed for successful build per INSTALL
adds dependency of nodejs-legacy per INSTALL

This will not enforce the version of the nodejs package, which is in the Backports branch for Wheezy, thus build attempts on Wheezy will now fail if the main nodejs package is installed, and require the user to uninstall it and reinstall with backports. Unsure of the impact to Jessy.