### PR TITLE
[Makefile] -X ... ... => -X ...=...

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -118,10 +118,10 @@ $(BIN_OUTPUT): $(PKG_SRC) $(BIN_SRC) $(BUILD_DIR)/src/github.com/facette/facette
 	@$(call mesg_start,$(notdir $@),Building $(notdir $@)...)
 	@install -d -m 0755 $(dir $@) && $(GO) build \
 			-ldflags " \
-				-X main.version $(VERSION) \
-				-X main.buildDate '$(BUILD_DATE)' \
-				$(PKG_LIST:%=-X github.com/facette/facette/%.version $(VERSION)) \
-				$(PKG_LIST:%=-X github.com/facette/facette/%.buildDate '$(BUILD_DATE)') \
+				-X main.version=$(VERSION) \
+				-X main.buildDate='$(BUILD_DATE)' \
+				$(PKG_LIST:%=-X github.com/facette/facette/%.version=$(VERSION)) \
+				$(PKG_LIST:%=-X github.com/facette/facette/%.buildDate='$(BUILD_DATE)') \
 			" \
 			-tags "$(TAGS)" \
 			-o $@ cmd/$(notdir $@)/*.go && \


### PR DESCRIPTION
With go1.5.2 and facette 0.3.0 I get the following compile warnings
```
facette: Building facette...
# command-line-arguments
link: warning: option -X main.version 0.3.0 may not work in future releases; use -X main.version=0.3.0
link: warning: option -X main.buildDate 2015-12-05 may not work in future releases; use -X main.buildDate=2015-12-05
link: warning: option -X github.com/facette/facette/pkg/config.version 0.3.0 may not work in future releases; use -X github.com/facette/facette/pkg/config.version=0.3.0
link: warning: option -X github.com/facette/facette/pkg/logger.version 0.3.0 may not work in future releases; use -X github.com/facette/facette/pkg/logger.version=0.3.0
link: warning: option -X github.com/facette/facette/pkg/plot.version 0.3.0 may not work in future releases; use -X github.com/facette/facette/pkg/plot.version=0.3.0
link: warning: option -X github.com/facette/facette/pkg/connector.version 0.3.0 may not work in future releases; use -X github.com/facette/facette/pkg/connector.version=0.3.0
link: warning: option -X github.com/facette/facette/pkg/server.version 0.3.0 may not work in future releases; use -X github.com/facette/facette/pkg/server.version=0.3.0
link: warning: option -X github.com/facette/facette/pkg/cmd.version 0.3.0 may not work in future releases; use -X github.com/facette/facette/pkg/cmd.version=0.3.0
...
```

The same goes for `facettectl: Building facettectl...`.

Please check, weather the proposed new syntax works with your go version (I haven't looked up since when `...=...` is possible)