### PR TITLE
OpenBSD doesn't have pandoc either

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,8 +95,8 @@ clean: clean-bin clean-doc clean-static clean-test clean-dist
 	@(test ! -d $(BUILD_DIR) || rmdir $(BUILD_DIR)) && \
 		$(call mesg_ok) || $(call mesg_fail)
 
-# NetBSD doesn't have pandoc packaged yet
-ifneq ($(UNAME), NetBSD)
+# OpenBSD/NetBSD doesn't have pandoc packaged yet
+ifneq ($(filter (OpenBSD NetBSD), $(UNAME)),)
 do_buid_docs = build-doc
 endif
 


### PR DESCRIPTION
Easy one, following what @iMilnb did for NetBSD.. facette binary just builds fine here, i just need to pass `CGO_LDFLAGS="-Wl,-rpath -Wl,/usr/X11R6/lib"`  in the gmake env so that it finds the X11 dependencies of librrd. Dunno if that should be handled directly in the Makefile, i can add this to the PR if needed.
I didnt need to force the use of gsed, our sed seems to handle the regex just fine.