### PR TITLE
Use full path when applicable

### DIFF
--- a/docs/examples/facette.yaml
+++ b/docs/examples/facette.yaml
@@ -17,7 +17,7 @@ backend:
 
   ### SQLite
   driver: sqlite
-  path: data.db
+  path: /var/lib/facette/data.db
 
   ### PostgreSQL
   #driver: pgsql
@@ -37,7 +37,7 @@ backend:
 
 frontend:
   enabled: true
-  assets_dir: assets
+  assets_dir: /usr/local/share/facette/assets
 
 hide_build_details: false
 


### PR DESCRIPTION
Using the default full path for assets and a full-path for the SQLite database makes it easier to figure-out what to put in the configuration file.