### PR TITLE
Add optional basic authorization

### DIFF
--- a/docs/examples/facette.yaml
+++ b/docs/examples/facette.yaml
@@ -45,4 +45,7 @@ hide_build_details: false
 
 read_only: false
 
+# username: facette
+# password: facette
+
 # vim: ts=2 sw=2 et

--- a/src/cmd/facette/config.go
+++ b/src/cmd/facette/config.go
@@ -42,6 +42,8 @@ type config struct {
 	DefaultTimeRange string         `yaml:"default_time_range"`
 	HideBuildDetails bool           `yaml:"hide_build_details"`
 	ReadOnly         bool           `yaml:"read_only"`
+	Username         string         `yaml:"username"`
+	Password         string         `yaml:"password"`
 }
 
 func initConfig(path string) (*config, error) {

--- a/src/cmd/facette/http_logger.go
+++ b/src/cmd/facette/http_logger.go
@@ -21,6 +21,14 @@ func (rw responseWriter) WriteHeader(status int) {
 
 func (w *httpWorker) httpHandleLogger(h http.Handler) http.Handler {
 	return http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+		if w.service.config.Username != "" && w.service.config.Password != "" {
+			user, pass, _ := r.BasicAuth()
+			if user != w.service.config.Username || pass != w.service.config.Password {
+				rw.Header().Set("WWW-Authenticate", `Basic realm="Restricted"`)
+				http.Error(rw, "Unauthorized.", 401)
+				return
+			}
+		}
 		h.ServeHTTP(responseWriter{rw, r, w.log}, r)
 	})
 }


### PR DESCRIPTION
This commit contains optional HTTP basic authorization. If username **and** password are set in the configuration file, they will be required to use Facette. Note that, if username **or** password is not set or empty then no authorization will not be requested.