### PR TITLE
Implement support for Syslog logging

### DIFF
--- a/src/cmd/facette/config.go
+++ b/src/cmd/facette/config.go
@@ -17,6 +17,8 @@ const (
 	defaultRootPath          = "/"
 	defaultLogPath           = ""
 	defaultLogLevel          = "info"
+	defaultSyslogFacility    = "daemon"
+	defaultSyslogTag         = "facette"
 	defaultFrontendEnabled   = true
 	defaultFrontendAssetsDir = "assets"
 	defaultTimeRange         = "-1h"
@@ -37,6 +39,11 @@ type config struct {
 	RootPath         string         `yaml:"root_path"`
 	LogPath          string         `yaml:"log_path"`
 	LogLevel         string         `yaml:"log_level"`
+	SyslogLevel      string         `yaml:"syslog_level"`
+	SyslogFacility   string         `yaml:"syslog_facility"`
+	SyslogTag        string         `yaml:"syslog_tag"`
+	SyslogAddress    string         `yaml:"syslog_address"`
+	SyslogTransport  string         `yaml:"syslog_transport"`
 	Frontend         frontendConfig `yaml:"frontend"`
 	Backend          *maputil.Map   `yaml:"backend"`
 	DefaultTimeRange string         `yaml:"default_time_range"`
@@ -52,6 +59,8 @@ func initConfig(path string) (*config, error) {
 			RootPath:        defaultRootPath,
 			LogPath:         defaultLogPath,
 			LogLevel:        defaultLogLevel,
+			SyslogFacility:  defaultSyslogFacility,
+			SyslogTag:       defaultSyslogTag,
 			Frontend: frontendConfig{
 				Enabled:   defaultFrontendEnabled,
 				AssetsDir: defaultFrontendAssetsDir,

--- a/src/cmd/facette/service.go
+++ b/src/cmd/facette/service.go
@@ -33,10 +33,28 @@ func NewService(config *config) *Service {
 
 // Run starts the service processing.
 func (s *Service) Run() error {
-	var err error
+	var (
+		loggers = make([]interface{}, 0)
+		err     error
+	)
 
 	// Initialize logger
-	s.log, err = logger.NewLogger(logger.FileConfig{Level: s.config.LogLevel, Path: s.config.LogPath})
+	loggers = append(loggers, logger.FileConfig{
+		Level: s.config.LogLevel,
+		Path:  s.config.LogPath,
+	})
+
+	if s.config.SyslogLevel != "" {
+		loggers = append(loggers, logger.SyslogConfig{
+			Level:     s.config.SyslogLevel,
+			Facility:  s.config.SyslogFacility,
+			Tag:       s.config.SyslogTag,
+			Address:   s.config.SyslogAddress,
+			Transport: s.config.SyslogTransport,
+		})
+	}
+
+	s.log, err = logger.NewLogger(loggers...)
 	if err != nil {
 		return err
 	}

--- a/vendor/manifest
+++ b/vendor/manifest
@@ -28,7 +28,7 @@
 		{
 			"importpath": "github.com/facette/logger",
 			"repository": "https://github.com/facette/logger",
-			"revision": "ded3054c57b9b4deaf4f0a82949e5329c4d030df",
+			"revision": "60ca3a8b846b4034dc8e93e725ac5d02388ae780",
 			"branch": "master"
 		},
 		{

--- a/vendor/src/github.com/facette/logger/file.go
+++ b/vendor/src/github.com/facette/logger/file.go
@@ -46,8 +46,10 @@ func newFileBackend(config FileConfig, logger *Logger) (backend, error) {
 		// Create parent folders if needed
 		dirPath, _ := path.Split(config.Path)
 
-		if err = os.MkdirAll(dirPath, 0755); err != nil {
-			return nil, err
+		if dirPath != "" {
+			if err = os.MkdirAll(dirPath, 0755); err != nil {
+				return nil, err
+			}
 		}
 
 		// Open logging output file

--- a/vendor/src/github.com/facette/logger/logger.go
+++ b/vendor/src/github.com/facette/logger/logger.go
@@ -24,13 +24,16 @@ const (
 	LevelDebug
 )
 
-var levelMap = map[string]int{
-	"error":   LevelError,
-	"warning": LevelWarning,
-	"notice":  LevelNotice,
-	"info":    LevelInfo,
-	"debug":   LevelDebug,
-}
+var (
+	logger   *Logger
+	levelMap = map[string]int{
+		"error":   LevelError,
+		"warning": LevelWarning,
+		"notice":  LevelNotice,
+		"info":    LevelInfo,
+		"debug":   LevelDebug,
+	}
+)
 
 // Logger represents a logger instance.
 type Logger struct {
@@ -40,6 +43,10 @@ type Logger struct {
 	wg sync.WaitGroup
 
 	sync.Mutex
+}
+
+func init() {
+	logger, _ = NewLogger(FileConfig{Level: "debug"})
 }
 
 // NewLogger returns a new Logger instance initialized with the given configuration.
@@ -103,10 +110,20 @@ func (l *Logger) Error(format string, v ...interface{}) *Logger {
 	return l
 }
 
+// Error prints an error message using the default logger.
+func Error(format string, v ...interface{}) {
+	logger.Error(format, v...)
+}
+
 // Warning prints a warning message in the logging system.
 func (l *Logger) Warning(format string, v ...interface{}) *Logger {
 	l.write(LevelWarning, format, v...)
 	return l
+}
+
+// Warning prints a warning message using the default logger.
+func Warning(format string, v ...interface{}) {
+	logger.Warning(format, v...)
 }
 
 // Notice prints a notice message in the logging system.
@@ -115,16 +132,31 @@ func (l *Logger) Notice(format string, v ...interface{}) *Logger {
 	return l
 }
 
+// Notice prints a notice message using the default logger.
+func Notice(format string, v ...interface{}) {
+	logger.Notice(format, v...)
+}
+
 // Info prints an information message in the logging system.
 func (l *Logger) Info(format string, v ...interface{}) *Logger {
 	l.write(LevelInfo, format, v...)
 	return l
 }
 
+// Info prints an information message using the default logger.
+func Info(format string, v ...interface{}) {
+	logger.Info(format, v...)
+}
+
 // Debug prints a debug message in the logging system.
 func (l *Logger) Debug(format string, v ...interface{}) *Logger {
 	l.write(LevelDebug, format, v...)
 	return l
+}
+
+// Debug prints a debug message using the default logger.
+func Debug(format string, v ...interface{}) {
+	logger.Debug(format, v...)
 }
 
 // Close closes the logger output file.


### PR DESCRIPTION
This change implements #329.

To enable syslog logging, set a valid value for setting `syslog_level` in the facette.yaml configuration file.