### PR TITLE
Make systemd service robust to permission issues

### DIFF
--- a/debian/facette.service
+++ b/debian/facette.service
@@ -5,9 +5,13 @@ After=network.target
 
 [Service]
 Type=simple
+ExecStartPre=/bin/mkdir -p /run/facette
+ExecStartPre=/bin/chown facette: /run/facette
+ExecStartPre=/bin/bash -c 'rm -f $(grep "listen.*unix:.*\.sock" /etc/facette/facette.yaml|cut -d: -f3)'
 ExecStart=/usr/bin/facette
 User=facette
 Group=facette
+PermissionsStartOnly=true
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
In order for facette to successfully start there are some preconditions to be met:

 * directory in /run should exist and permissions should allow to write facette user to it
 * if facette listens on UNIX socket it should not exist when starting facette service